### PR TITLE
Fix: Change page title to testah

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import starlight from '@astrojs/starlight';
 export default defineConfig({
 	integrations: [
 		starlight({
-			title: 'Les outils',
+			title: 'testah',
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/withastro/starlight' }],
 			sidebar: [
 				{


### PR DESCRIPTION
This commit changes the page title from 'Les outils' to 'testah' in the Astro configuration file.